### PR TITLE
remove initContainers

### DIFF
--- a/.bin/local-test.sh
+++ b/.bin/local-test.sh
@@ -14,8 +14,24 @@ set -o pipefail
 
 CERT_DIR=${CERT_DIR:-$(mktemp -d)}
 NAMESPACE=ds
-KIND_CLUSTER_NAME=kind
+	K8S_EMU=kind
 
+for arg in "$@"; do
+    if [[ "$arg" == "--minikube" ]]; then
+	K8S_EMU=minikube
+	break
+    fi
+done
+
+if [[ "$K8S_EMU" == 'minikube' ]];
+then
+    minikube start
+fi
+
+if [[ "$K8S_EMU" == 'kind' ]];
+then
+
+KIND_CLUSTER_NAME=kind
 
 if ! kind get clusters -q | grep -q $KIND_CLUSTER_NAME; then
 
@@ -121,6 +137,9 @@ EOF
 EOF
 
 fi
+fi
+
+kubectl get nodes -v10 || exit 1
 
 for arg in "$@"; do
     if [[ "$arg" == "--envoy" ]]; then

--- a/.bin/local-test.sh
+++ b/.bin/local-test.sh
@@ -25,8 +25,11 @@ done
 
 if [[ "$K8S_EMU" == 'minikube' ]];
 then
-    minikube start
+    if ! minikube status | grep -q 'host: Running'; then
+	minikube start
+    fi
 fi
+
 
 if [[ "$K8S_EMU" == 'kind' ]];
 then

--- a/.bin/myval.yaml
+++ b/.bin/myval.yaml
@@ -21,7 +21,7 @@ ltb-passwd:
     hosts:
     - "ssl-ldap2.example"
 phpldapadmin:
-  enabled: false
+  enabled: true
   ingress:
     hosts:
     - "phpldapadmin.example"

--- a/.bin/myval.yaml
+++ b/.bin/myval.yaml
@@ -21,6 +21,7 @@ ltb-passwd:
     hosts:
     - "ssl-ldap2.example"
 phpldapadmin:
+  enabled: true
   ingress:
     hosts:
     - "phpldapadmin.example"

--- a/.bin/myval.yaml
+++ b/.bin/myval.yaml
@@ -111,9 +111,4 @@ service:
   type: NodePort
 initTLSSecret:
   tls_enabled: true
-  image:
-    registry: docker.io
-    repository: alpine/openssl
-    tag: latest
-    pullPolicy: IfNotPresent
-  secret: "myval-certs"
+  secret: "myval-tls-certs"

--- a/.bin/myval.yaml
+++ b/.bin/myval.yaml
@@ -113,3 +113,5 @@ service:
 initTLSSecret:
   tls_enabled: true
   secret: "myval-tls-certs"
+replication:
+  tls_enabled: true

--- a/.bin/myval.yaml
+++ b/.bin/myval.yaml
@@ -21,7 +21,7 @@ ltb-passwd:
     hosts:
     - "ssl-ldap2.example"
 phpldapadmin:
-  enabled: true
+  enabled: false
   ingress:
     hosts:
     - "phpldapadmin.example"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: openldap
 home: https://www.openldap.org
-version: 1.1.4
+version: 1.1.6
 appVersion: 2.6.8
 description: The OpenLDAP directory server, with support from Symas Corp.
 icon: https://raw.githubusercontent.com/symas/helm-openldap/master/logo.png

--- a/NOTES
+++ b/NOTES
@@ -32,14 +32,59 @@ for (( i=1; i<10000; i++ )) ; do openssl s_client  -connect openldap-0.openldap-
 
 
 
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          namespace: {{ .Release.Namespace }}
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/component: {{ template "openldap.fullname" . }}
-          release: {{ .Release.Name }}
+
+        - name: init-schema
+          image: {{ include "openldap.initSchemaImage" . }}
+          imagePullPolicy: {{ .Values.initSchema.image.pullPolicy | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              cp -p -f /cm-schemas-acls/*.ldif /custom-config/
+              if [ -d /cm-schemas ]; then
+                cp -p -f /cm-schemas/*.ldif /custom-schemas/
+              fi
+              if [ -d /cm-ldifs ]; then
+                cp -p -f /cm-ldifs/*.ldif /custom-ldifs/
+              fi
+            {{- if .Values.global.existingSecret }}
+              sed -i -e "s/%%CONFIG_PASSWORD%%/${LDAP_CONFIG_ADMIN_PASSWORD}/g" /custom-config/*
+              sed -i -e "s/%%ADMIN_PASSWORD%%/${LDAP_ADMIN_PASSWORD}/g" /custom-config/*
+            {{- end }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.initTLSSecret.resources }}
+          resources: {{- toYaml .Values.initTLSSecret.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+    {{- if .Values.customSchemaFiles }}
+      {{- range $file := (include "openldap.customSchemaFiles" . | split ",") }}
+            - name: cm-custom-schema-files
+              mountPath: /cm-schemas/{{ $file }}.ldif
+              subPath: {{ $file }}.ldif
+      {{- end }}
+            - name: custom-schema-files
+              mountPath: /custom-schemas/
+    {{- end }}
+    {{- if or (.Values.customLdifFiles) (.Values.customLdifCm) }}
+            - name: cm-custom-ldif-files
+              mountPath: /cm-ldifs/
+            - name: custom-ldif-files
+              mountPath: /custom-ldifs/
+    {{- end }}
+            - name: cm-replication-acls
+              mountPath: /cm-schemas-acls/
+            - name: replication-acls
+              mountPath: /custom-config/
+    {{- if .Values.global.existingSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ template "openldap.secretName" . }}
+    {{- end }}
+      {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
 
 
 -------------

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ mkShell rec {
     shelldap
     stern
     shellcheck
+    tmate
     lsof
   ];
   shellHook =

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,11 +2,11 @@
 
 OpenLDAP has been installed. You can access the server from within the k8s cluster using:
 
-  {{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.ldapPort }}
+  {{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.global.ldapPort }}
 
   Or, via SSL/TLS at:
 
-  {{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.sslLdapPort }}
+  {{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.global.sslLdapPort }}
 
 
 You can access the LDAP adminPassword and configPassword using:
@@ -16,7 +16,7 @@ You can access the LDAP adminPassword and configPassword using:
 
 
 You can access the LDAP service, from within the cluster (or with kubectl port-forward) with a command like (replace password and domain):
-  ldapsearch -x -H ldap://{{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.ldapPort }} -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w $LDAP_ADMIN_PASSWORD
+  ldapsearch -x -H ldap://{{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.global.ldapPort }} -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w $LDAP_ADMIN_PASSWORD
 
 
 {{- if .Values.phpldapadmin.enabled }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -55,11 +55,12 @@ Generate olcServerID list
 {{- define "olcServerIDs" }}
 {{- $name := (include "openldap.fullname" .) }}
 {{- $namespace := .Release.Namespace }}
+{{- $port := .Values.global.ldapPort }}
 {{- $cluster := .Values.replication.clusterName }}
 {{- $nodeCount := .Values.replicaCount | int }}
   {{- range $index0 := until $nodeCount }}
     {{- $index1 := $index0 | add1 }}
-    olcServerID: {{ $index1 }} ldap://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:1389
+    olcServerID: {{ $index1 }} ldap://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:{{ $port }}
   {{- end -}}
 {{- end -}}
 
@@ -70,9 +71,11 @@ Generate olcSyncRepl list
 {{- $name := (include "openldap.fullname" .) }}
 {{- $namespace := .Release.Namespace }}
 {{- $domain := ternary (include "global.baseDomain" .) "cn=config" (empty .Values.global.ldapDomain) }}
+{{- $port := ternary .Values.global.sslLdapPort .Values.global.ldapPort .Values.replication.tls_enabled }}
+{{- $protocol := ternary "ldaps" "ldap" .Values.replication.tls_enabled }}
 {{- $bindDNUser := .Values.global.adminUser }}
 {{- $cluster := .Values.replication.clusterName }}
-{{- $configPassword :=  ternary .Values.global.configPassword "%%CONFIG_PASSWORD%%" (empty .Values.global.existingSecret) }}
+{{- $adminPassword :=  ternary .Values.global.configPassword "%%CONFIG_PASSWORD%%" (empty .Values.global.existingSecret) }}
 {{- $retry := .Values.replication.retry }}
 {{- $timeout := .Values.replication.timeout }}
 {{- $network_timeout := .Values.replication.network_timeout }}
@@ -80,10 +83,11 @@ Generate olcSyncRepl list
 {{- $starttls := .Values.replication.starttls }}
 {{- $tls_reqcert := .Values.replication.tls_reqcert }}
 {{- $tls_cacert := .Values.replication.tls_cacert }}
+{{- $interval := .Values.replication.interval }}
 {{- $nodeCount := .Values.replicaCount | int }}
   {{- range $index0 := until $nodeCount }}
     {{- $index1 := $index0 | add1 }}
-    olcSyncRepl: rid=00{{ $index1 }} provider=ldap://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:1389 binddn="{{ printf "cn=%s,%s" $bindDNUser $domain }}" bindmethod=simple credentials={{ $configPassword }} searchbase="cn=config" type=refreshAndPersist retry="{{ $retry }} +" timeout={{ $timeout }} network-timeout={{ $network_timeout }} tcp-user-timeout=0 keepalive={{ $keepalive }} starttls={{ $starttls }} filter="(objectclass=*)" logfilter="(&(objectClass=auditWriteObject)(reqResult=0))" logbase="cn=accesslog" scope=sub schemachecking=on type=refreshAndPersist retry="60 +" syncdata=accesslog tls_reqcert={{ $tls_reqcert }} tls_cacert={{ $tls_cacert }}
+    olcSyncRepl: rid=00{{ $index1 }} provider={{ $protocol }}://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:{{ $port }} binddn="{{ printf "cn=%s,%s" $bindDNUser $domain }}" bindmethod=simple credentials={{ $adminPassword }} searchbase={{ $domain }} type=refreshAndPersist interval={{ $interval }} retry="{{ $retry }} +" timeout={{ $timeout }} network-timeout={{ $network_timeout }} tcp-user-timeout=0 keepalive={{ $keepalive }} starttls={{ $starttls }} filter="(objectclass=*)" scope=sub schemachecking=on retry="60 +" tls_reqcert={{ $tls_reqcert }} tls_cacert={{ $tls_cacert }}
   {{- end -}}
 {{- end -}}
 
@@ -92,33 +96,47 @@ Generate olcSyncRepl list
 */}}
 {{- define "olcSyncRepls2" -}}
 {{- $name := (include "openldap.fullname" .) }}
-{{- $domain := (include "global.baseDomain" .) }}
-{{- $bindDNUser := .Values.global.adminUser }}
 {{- $namespace := .Release.Namespace }}
+{{- $domain := (include "global.baseDomain" .) }}
+{{- $port := ternary .Values.global.sslLdapPort .Values.global.ldapPort .Values.replication.tls_enabled }}
+{{- $protocol := ternary "ldaps" "ldap" .Values.replication.tls_enabled }}
+{{- $bindDNUser := .Values.global.adminUser }}
 {{- $cluster := .Values.replication.clusterName }}
 {{- $adminPassword := ternary .Values.global.adminPassword "%%ADMIN_PASSWORD%%" (empty .Values.global.existingSecret) }}
 {{- $retry := .Values.replication.retry }}
 {{- $timeout := .Values.replication.timeout }}
+{{- $network_timeout := .Values.replication.network_timeout }}
+{{- $keepalive := .Values.replication.keepalive }}
 {{- $starttls := .Values.replication.starttls }}
 {{- $tls_reqcert := .Values.replication.tls_reqcert }}
+{{- $tls_cacert := .Values.replication.tls_cacert }}
 {{- $interval := .Values.replication.interval }}
 {{- $nodeCount := .Values.replicaCount | int }}
   {{- range $index0 := until $nodeCount }}
     {{- $index1 := $index0 | add1 }}
     olcSyncrepl:
-      rid=10{{ $index1 }}
-      provider=ldap://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:1389
+      rid=00{{ $index1 }}
+      provider={{ $protocol }}://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:{{ $port }}
       binddn={{ printf "cn=%s,%s" $bindDNUser $domain }}
       bindmethod=simple
       credentials={{ $adminPassword }}
       searchbase={{ $domain }}
       type=refreshAndPersist
       interval={{ $interval }}
-      network-timeout=0
+      retry="{{ $retry }} +"
+      timeout={{ $timeout }}
+      network-timeout={{ $network_timeout }}
+      tcp-user-timeout=0
+      keepalive={{ $keepalive }}
       retry="{{ $retry }} +"
       timeout={{ $timeout }}
       starttls={{ $starttls }}
+      filter="(objectclass=*)"
+      scope=sub
+      schemachecking=on
+      retry="60 +"
       tls_reqcert={{ $tls_reqcert }}
+      tls_cacert={{ $tls_cacert }}
   {{- end -}}
 {{- end -}}
 
@@ -180,7 +198,7 @@ Cannot return list => return string comma separated
 {{- define "openldap.replicationConfigFiles" -}}
   {{- $schemas := "" -}}
   {{- if .Values.replication.enabled -}}
-    {{- $schemas = "01_serverid-modify,02_rep-modify,03_brep-modify,04_acls-modify,syncprov,delta-sycnrepl" -}}
+    {{- $schemas = "00_syncprov-load,01_serverid-modify,02_rep-modify,03_brep-modify,05_syncprov,06_acls-modify" -}}
   {{- else -}}
     {{- $schemas = "acls" -}}
   {{- end -}}
@@ -276,9 +294,9 @@ Generate certificates for the openldap server
 {{- define "openldap.gen-certs" -}}
 {{- $altNames := list ( include "openldap.fullname" . ) ( printf "%s.%s" (include "openldap.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "openldap.fullname" .) .Release.Namespace ) ( include "openldap-headless-names" . ) -}}
 {{- $caName := printf "%s.%s.svc.%s" (include "openldap.fullname" .) .Release.Namespace .Values.replication.clusterName -}}
-{{- $ca := genCA "openldap-ca" 365 -}}
+{{- $ca := genCA ( printf "%s-ca" $caName) 365 -}}
 {{- $cert := genSignedCert $caName nil $altNames 365 $ca -}}
-ca.crt: {{ $cert.Cert | b64enc }}
+ca.crt: {{ $ca.Cert | b64enc }}
 tls.crt: {{ $cert.Cert | b64enc }}
 tls.key: {{ $cert.Key | b64enc }}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -266,7 +266,7 @@ Generate certificate names list
 {{- $cluster := .Values.replication.clusterName }}
 {{- $nodeCount := .Values.replicaCount | int }}
   {{- range $index0 := until $nodeCount }}
-    {{- $index1 := $index0 | add1 }} {{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}
+    {{- $index1 := $index0 | add1 }} {{ $name }}-{{ $index0 }} {{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}
   {{- end -}}
 {{- end -}}
 

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -30,9 +30,9 @@ data:
   {{- end }}
   {{- if .Values.initTLSSecret.tls_enabled}}
   LDAP_ENABLE_TLS: "yes"
-  LDAP_TLS_CERT_FILE: /opt/bitnami/openldap/certs/tls.crt
-  LDAP_TLS_KEY_FILE: /opt/bitnami/openldap/certs/tls.key
-  LDAP_TLS_CA_FILE: /opt/bitnami/openldap/certs/ca.crt
+  LDAP_TLS_CERT_FILE: /certs/tls.crt
+  LDAP_TLS_KEY_FILE: /certs/tls.key
+  LDAP_TLS_CA_FILE: /certs/ca.crt
   {{- else }}
   LDAP_ENABLE_TLS: "no"
   {{- end }}

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -45,4 +45,5 @@ data:
   {{- if .Values.replication.enabled }}
   LDAP_SYNCPROV_ENABLE: "yes"
   {{- end }}
+  LDAP_TLS_VERIFY_CLIENT: "try"
 {{ toYaml .Values.env | indent 2 }}

--- a/templates/configmap-replication-acls.yaml
+++ b/templates/configmap-replication-acls.yaml
@@ -13,14 +13,7 @@ metadata:
 {{- end }}
 data:
   # replication
-  delta-syncrepl.ldif: |
-    # Load delta-syncrepl module
-    dn: cn=module,cn=config
-    cn: module
-    objectClass: olcModuleList
-    olcModuleLoad: delta-syncrepl.so
-    olcModulePath: /opt/bitnami/openldap/lib/openldap
-  syncprov.ldif: |
+  00_syncprov-load.ldif: |
     # Load syncprov module
     dn: cn=module,cn=config
     cn: module
@@ -52,8 +45,19 @@ data:
     changetype: modify
     add: olcMirrorMode
     olcMirrorMode: TRUE
-  # acls
-  04_acls-modify.ldif: |
+  04_syncprov.ldif: |
+    dn: olcOverlay=syncprov,olcDatabase={0}config,cn=config
+    objectClass: olcOverlayConfig
+    objectClass: olcSyncProvConfig
+    olcSpCheckpoint: 100 10
+    olcSpSessionlog: 50000
+  05_syncprov.ldif: |
+    dn: olcOverlay=syncprov,olcDatabase={2}mdb,cn=config
+    objectClass: olcOverlayConfig
+    objectClass: olcSyncProvConfig
+    olcSpCheckpoint: 100 10
+    olcSpSessionlog: 55000000
+  06_acls-modify.ldif: |
 {{- if .Values.customAcls }}
     {{- .Values.customAcls | nindent 4 }}
 {{- else }}

--- a/templates/networkpolicy-ldap-allow-all.yaml
+++ b/templates/networkpolicy-ldap-allow-all.yaml
@@ -1,0 +1,23 @@
+# allows all pods to connect on ldap port
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "openldap.fullname" . }}-allow-ldap-ports
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: {{ template "openldap.fullname" . }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ template "openldap.fullname" . }}
+      release: {{ .Release.Name }}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: ldap-port
+    - protocol: TCP
+      port: ssl-ldap-port
+  - from:
+    - namespaceSelector: {}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -89,32 +89,6 @@ spec:
       {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.initTLSSecret.tls_enabled}}
-        - name: init-tls-secret
-          image: {{ include "openldap.initTLSSecretImage" . }}
-          imagePullPolicy: {{ .Values.initTLSSecret.image.pullPolicy | quote }}
-          command:
-            - sh
-            - -c
-            - |
-              {{- if and ( .Values.initTLSSecret.tls_enabled ) (hasKey .Values.initTLSSecret "secret") (eq .Values.initTLSSecret.secret "") }}
-              openssl req -x509 -newkey rsa:4096 -nodes -subj '/CN={{ .Values.global.ldapDomain }}' -keyout /tmp-certs/tls.key -out /tmp-certs/tls.crt -days 365
-              chmod 777  /tmp-certs/*
-              {{- end }}
-              cp -Lr /tmp-certs/* /certs
-              [ -e /certs/ca.crt ] || cp -a /certs/tls.crt /certs/ca.crt
-          {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
-          {{- if .Values.initTLSSecret.resources }}
-          resources: {{- toYaml .Values.initTLSSecret.resources | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: certs
-              mountPath: "/certs"
-            - name: secret-certs
-              mountPath: "/tmp-certs"
-      {{- end }}
       {{- if .Values.volumePermissions.enabled }}
         - name: volume-permissions
           image: {{ include "openldap.volumePermissionsImage" . }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -148,9 +148,9 @@ spec:
           {{- end }}
           ports:
             - name: ldap-port
-              containerPort: 1389
+              containerPort: {{ .Values.global.ldapPort }}
             - name: ssl-ldap-port
-              containerPort: 1636
+              containerPort: {{ .Values.global.sslLdapPort }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -86,25 +86,6 @@ spec:
           - secretRef:
               name: {{ template "openldap.secretName" . }}
     {{- end }}
-      {{- if .Values.initContainers }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
-      {{- end }}
-      {{- if .Values.volumePermissions.enabled }}
-        - name: volume-permissions
-          image: {{ include "openldap.volumePermissionsImage" . }}
-          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.volumePermissions.image.command "context" $) | nindent 12 }}
-          {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
-          {{- if .Values.volumePermissions.resources }}
-          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /bitnami
-              name: data
-      {{- end }}
-
       serviceAccountName: {{ template "openldap.serviceAccountName" . }}
       {{- include "openldap.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -209,7 +209,7 @@ spec:
             - name: data
               mountPath: /openldap
             - name: certs
-              mountPath: /opt/bitnami/openldap/certs
+              mountPath: /certs
               readOnly: true
             {{- range $file := (include "openldap.replicationConfigFiles" . | split ",") }}
             - name: replication-acls
@@ -280,15 +280,12 @@ spec:
           emptyDir:
             medium: Memory
 {{- end }}
-        - name: certs
-          emptyDir:
-            medium: Memory
 {{- if and ( .Values.initTLSSecret.tls_enabled ) (hasKey .Values.initTLSSecret "secret") (ne .Values.initTLSSecret.secret "") }}
-        - name: secret-certs
+        - name: certs
           secret:
             secretName: {{ .Values.initTLSSecret.secret }}
 {{- else }}
-        - name: secret-certs
+        - name: certs
           emptyDir:
             medium: Memory
 {{- end }}

--- a/templates/tests/openldap-tests.yaml
+++ b/templates/tests/openldap-tests.yaml
@@ -17,6 +17,6 @@ data:
       # Ideally, this should be in the docker image, but there is not a generic image we can use
       # with bats and ldap-utils installed. It is not worth for now to push an image for this.
       apt-get update && apt-get install -y ldap-utils
-      ldapsearch -x -H ldap://{{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ldapPort }} -b "dc=example,dc=org" -D "cn=admin,dc=example,dc=org" -w $LDAP_ADMIN_PASSWORD
+      ldapsearch -x -H ldap://{{ template "openldap.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.ldapPort }} -b "dc=example,dc=org" -D "cn=admin,dc=example,dc=org" -w $LDAP_ADMIN_PASSWORD
     }
 {{- end -}}

--- a/templates/tls-secret.yaml
+++ b/templates/tls-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and ( .Values.initTLSSecret.tls_enabled ) (hasKey .Values.initTLSSecret "secret") (ne .Values.initTLSSecret.secret "") ( .Values.initTLSSecret.tls_gencert ) }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ .Values.initTLSSecret.secret }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+{{- if $.Values.extraLabels }}
+{{ toYaml $.Values.extraLabels | indent 4 }}
+{{- end }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+{{ ( include "openldap.gen-certs" . ) | indent 2 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -198,7 +198,7 @@ replication:
   interval: 00:00:00:10
   starttls: "yes"
   tls_reqcert: "allow"
-  tls_cacert: /opt/bitnami/openldap/certs/ca.crt
+  tls_cacert: /certs/ca.crt
 
 ## Persist data to a persistent volume
 persistence:

--- a/values.yaml
+++ b/values.yaml
@@ -402,35 +402,9 @@ serviceAccount:
 ##
 initTLSSecret:
   tls_enabled: false
-  ##  openssl image
-  ## @param initTlsSecret.image.registry openssl image registry
-  ## @param initTlsSecret.image.repository openssl image name
-  ## @param initTlsSecret.image.tag openssl image tag
-  ##
-  image:
-    registry: docker.io
-    repository: alpine/openssl
-    tag: latest
-    ## @param image.pullPolicy openssl image pull policy
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
+  tls_gencert: true
   # The name of a kubernetes.io/tls type secret to use for TLS
   secret: ""
-  ## init-tls-secret container's resource requests and limits
-  ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  ## @param initTlsSecret.resources.limits The resources limits for the init container
-  ## @param initTlsSecret.resources.requests The requested resources for the init container
-  ##
-  resources:
-    ## Example:
-    ## limits:
-    ##   cpu: 500m
-    ##   memory: 1Gi
-    limits: {}
-    requests: {}
 
 ## 'volumePermissions' init container parameters
 ## Changes the owner and group of the persistent volume mount point to runAsUser:fsGroup values

--- a/values.yaml
+++ b/values.yaml
@@ -196,7 +196,8 @@ replication:
   network_timeout: 0
   keepalive: 240:10:30
   interval: 00:00:00:10
-  starttls: "yes"
+  tls_enabled: true
+  starttls: "no"
   tls_reqcert: "allow"
   tls_cacert: /certs/ca.crt
 


### PR DESCRIPTION
### What this PR does / why we need it:
* Generates certificates using Helm rather than in an initContainer
* Fixes multiple oversights in replication configuration