### PR TITLE
Allow spaces to be used in syncrepl searchbase and binddn

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -117,10 +117,10 @@ Generate olcSyncRepl list
     olcSyncrepl:
       rid=00{{ $index1 }}
       provider={{ $protocol }}://{{ $name }}-{{ $index0 }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $cluster }}:{{ $port }}
-      binddn={{ printf "cn=%s,%s" $bindDNUser $domain }}
+      binddn="{{ printf "cn=%s,%s" $bindDNUser $domain }}"
       bindmethod=simple
       credentials={{ $adminPassword }}
-      searchbase={{ $domain }}
+      searchbase="{{ $domain }}"
       type=refreshAndPersist
       interval={{ $interval }}
       retry="{{ $retry }} +"


### PR DESCRIPTION
### What this PR does / why we need it:
This change allows `binddn` and `searchbase` to contain spaces in syncrepl configuration..

Otherwise, there will be errors such as `Error: parse_syncrepl_line: unable to parse` when trying to use a `binddn` and `searchbase` that contains spaces.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [N/A] Have you updated the readme?
* [N/A] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**